### PR TITLE
feat: keep build artifacts in different directories for each profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ INFO: building the core crate
 INFO: copy the core crate to the sysroot
 
 # check the sysroot
-$ tree target/sysroot
-target/sysroot
+$ tree target/sysroot/debug
+target/sysroot/debug
 ├── lib
 │   └── rustlib
 │       ├── $target
@@ -90,7 +90,7 @@ sysroot:
 [rust-lang/cargo#2241]: https://github.com/rust-lang/cargo/pull/2241
 
 ```
-$ RUSTFLAGS='--sysroot target/sysroot' cargo build --target $triple
+$ RUSTFLAGS='--sysroot target/sysroot/debug' cargo build --target $triple
    Compiling spin v0.3.5
    Compiling $crate v0.1.0 (file://...)
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,7 +243,8 @@ path = "lib.rs""#;
     }
 
     info!("copy the core crate to the sysroot");
-    let ref libdir = ctx.out_dir.join(format!("lib/rustlib/{}/lib", triple));
+    let profile = if ctx.release { "release" } else { "debug" };
+    let ref libdir = ctx.out_dir.join(format!("{}/lib/rustlib/{}/lib", profile, triple));
     try!(fs::create_dir_all(libdir));
 
     let ref src = temp_dir.join(format!("{}/{}/libcore.rlib",


### PR DESCRIPTION
Just like cargo does with the debug and release profiles.

This is a [breaking-change], the path of the build artifacts has changed.

In debug mode, i.e. `cargo sysroot --target $triple $out_dir`, the build
artifacts are now under the directory `$out_dir/debug`.

In release mode, i.e. `cargo sysroot --target $triple --release $out_dir`, the
build artifacts are now under the directory `$out_dir/release`.

Adjust the RUSTFLAGS variable accordingly. Either to
`RUSTFLAGS="--sysroot $out_dir/debug"` for the debug profile or to
`RUSTFLAGS="--sysroot $out_dir/release"` for the release profile.

---

cc @tjpeden