### PR TITLE
Run tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+install:
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo test --verbose

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -56,7 +56,8 @@ fn custom_target() {
           "llvm-target": "thumbv7m-none-eabi",
           "os": "none",
           "target-endian": "little",
-          "target-pointer-width": "32"
+          "target-pointer-width": "32",
+          "archive-format": "gnu"
         }
     "#;
     let td = t!(TempDir::new("cargo-sysroot"));


### PR DESCRIPTION
Avoids using symlinks on Windows which require administrator privileges and
instead just creates a bunch of hard links (falling back to copying files).